### PR TITLE
WRP-622: Update 'corejs' version in `@babel/preset-env` config 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-* Updated corejs version to `3.19`.
+* Updated `core-js` version of `@babel/preset-env` to `3.19`.
 
 ## 0.1.1 (February 17, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* Updated corejs version to `3.19`.
+
 ## 0.1.1 (February 17, 2023)
 
 * Updated Babel support:

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function (api) {
 					],
 					forceAllTransforms: es5Standalone,
 					useBuiltIns: 'entry',
-					corejs: '3.24'
+					corejs: '3.19'
 				}
 			],
 			[

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function (api) {
 					],
 					forceAllTransforms: es5Standalone,
 					useBuiltIns: 'entry',
-					corejs: '3.30'
+					corejs: '3.24'
 				}
 			],
 			[

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function (api) {
 					],
 					forceAllTransforms: es5Standalone,
 					useBuiltIns: 'entry',
-					corejs: 3
+					corejs: '3.30'
 				}
 			],
 			[


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] I have run automated CLI testing and it is passed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We are using 'core-js' 3 in @babel/preset-env but it seems old so it needs to be updated.
Please refer to https://babeljs.io/docs/en/babel-preset-env#corejs .
(`corejs: 3` will be interpreted as "3.0" which may not include polyfills for the latest features)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update `corejs` config to specify the minor version.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
For several reasons, we need to keep the `corejs` config to "3.19"
(Reference: WRP-622)

### Links
[//]: # (Related issues, references)
WRP-622

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)