### PR TITLE
WRQ-6438: Migrate deprecated rules to @stylistic/js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,12 +18,11 @@ module.exports = {
 			presets: [require.resolve('./index.js')]
 		}
 	},
-	plugins: ['@babel', 'import'],
+	plugins: ['@babel', '@stylistic/js', 'import'],
 	rules: {
 		'block-scoped-var': 'warn',
 		'curly': ['warn', 'multi-line'],
 		'eqeqeq': ['warn', 'smart'],
-		'new-parens': 'warn',
 		'no-alert': 'warn',
 		'no-array-constructor': 'warn',
 		'no-caller': 'error',
@@ -38,9 +37,7 @@ module.exports = {
 		'no-extend-native': 'warn',
 		'no-extra-bind': 'warn',
 		'no-extra-boolean-cast': 'warn',
-		'no-extra-semi': 'off',
 		'no-fallthrough': 'warn',
-		'no-floating-decimal': 'warn',
 		'no-func-assign': 'warn',
 		'no-implied-eval': 'warn',
 		'no-inner-declarations': 'off',
@@ -48,7 +45,6 @@ module.exports = {
 		'no-iterator': 'error',
 		'no-label-var': 'error',
 		'no-labels': 'error',
-		'no-mixed-spaces-and-tabs': ['warn', 'smart-tabs'],
 		'no-global-assign': 'error',
 		'no-unsafe-negation': 'error',
 		'no-new-func': 'error',
@@ -76,7 +72,6 @@ module.exports = {
 			}
 		],
 		'no-throw-literal': 'error',
-		'no-trailing-spaces': 'warn',
 		'no-unexpected-multiline': 'warn',
 		'no-unneeded-ternary': 'warn',
 		'no-unreachable': 'warn',
@@ -92,7 +87,14 @@ module.exports = {
 		'no-var': 'warn',
 		'require-yield': 'off',
 		'use-isnan': 'warn',
-		'wrap-iife': ['error', 'inside'],
+
+		// @stylistic/js plugin https://github.com/eslint-stylistic/eslint-stylistic
+		'@stylistic/js/new-parens': 'warn',
+		'@stylistic/js/no-extra-semi': 'off',
+		'@stylistic/js/no-floating-decimal': 'warn',
+		'@stylistic/js/no-mixed-spaces-and-tabs': ['warn', 'smart-tabs'],
+		'@stylistic/js/no-trailing-spaces': 'warn',
+		'@stylistic/js/wrap-iife': ['error', 'inside'],
 
 		// babel plugin https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin
 		'@babel/new-cap': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
 		'no-extend-native': 'warn',
 		'no-extra-bind': 'warn',
 		'no-extra-boolean-cast': 'warn',
+		'no-extra-semi': 'off',
 		'no-fallthrough': 'warn',
 		'no-func-assign': 'warn',
 		'no-implied-eval': 'warn',
@@ -45,6 +46,7 @@ module.exports = {
 		'no-iterator': 'error',
 		'no-label-var': 'error',
 		'no-labels': 'error',
+		'no-mixed-spaces-and-tabs': ['warn', 'smart-tabs'],
 		'no-global-assign': 'error',
 		'no-unsafe-negation': 'error',
 		'no-new-func': 'error',
@@ -90,9 +92,7 @@ module.exports = {
 
 		// @stylistic/js plugin https://github.com/eslint-stylistic/eslint-stylistic
 		'@stylistic/js/new-parens': 'warn',
-		'@stylistic/js/no-extra-semi': 'off',
 		'@stylistic/js/no-floating-decimal': 'warn',
-		'@stylistic/js/no-mixed-spaces-and-tabs': ['warn', 'smart-tabs'],
 		'@stylistic/js/no-trailing-spaces': 'warn',
 		'@stylistic/js/wrap-iife': ['error', 'inside'],
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* Replaced deprecated rules with `@stylistic/js` rules.
+
 ## 0.1.6 (December 21, 2023)
 
 * Updated dependencies.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@babel/eslint-plugin": "^7.23.5",
+        "@stylistic/eslint-plugin-js": "^1.5.4",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-prettier": "^5.1.2",
@@ -2111,6 +2112,48 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.5.4.tgz",
+      "integrity": "sha512-3ctWb3NvJNV1MsrZN91cYp2EGInLPSoZKphXIbIRx/zjZxKwLDr9z4LMOWtqjq14li/OgqUUcMq5pj8fgbLoTw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.3",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -2129,7 +2172,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2142,7 +2184,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -3080,7 +3121,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -3098,7 +3138,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -6301,6 +6340,32 @@
       "integrity": "sha512-Zwq5OCzuwJC2jwqmpEQt7Ds1DTi6BWSwoGkbb1n9pO3hzb35BoJELx7c0T23iDkBGkh2e7tvOtjF3tr3OaQHDQ==",
       "dev": true
     },
+    "@stylistic/eslint-plugin-js": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.5.4.tgz",
+      "integrity": "sha512-3ctWb3NvJNV1MsrZN91cYp2EGInLPSoZKphXIbIRx/zjZxKwLDr9z4LMOWtqjq14li/OgqUUcMq5pj8fgbLoTw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.11.3",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+          "dev": true
+        }
+      }
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -6318,15 +6383,13 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "ajv": {
@@ -7011,7 +7074,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -7022,8 +7084,7 @@
           "version": "3.4.3",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
           "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@babel/eslint-plugin": "^7.23.5",
+    "@stylistic/eslint-plugin-js": "^1.5.4",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prettier": "^5.1.2",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] I have run automated CLI testing and it is passed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
https://eslint.org/blog/2023/10/deprecating-formatting-rules/
The next minor release of ESLint(Eslint v8.53.0) will deprecate core formatting rules.

In https://eslint.org/blog/2023/10/deprecating-formatting-rules/#what-you-should-do-instead ,
Eslint suggests using a source code formatter (e.g. prettier, dprint) or `@stylistic/eslint-plugin-js`.
`@stylistic/eslint-plugin-js` contain the deprecated formatting rules from the ESLint core respectively.
Because the above module matches exactly same with the existing API, this module was selected instead of the source code formatter.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Migrate deprecated rules to `@stylistic/eslint-plugin-js`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-6438

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)